### PR TITLE
fix: migration config fixes added

### DIFF
--- a/src/common/database/orm.config.ts
+++ b/src/common/database/orm.config.ts
@@ -13,13 +13,11 @@ export const baseOptions = {
     return new NotFoundException(`${entityName} not found for ${key}`);
   },
   migrations: {
-    migrations: {
-      fileName: (timestamp: string, name?: string) => {
-        if (!name)
-          return `Migration${timestamp}`;
+    fileName: (timestamp: string, name?: string) => {
+      if (!name)
+        return `Migration${timestamp}`;
 
-        return `Migration${timestamp}_${name}`;
-      },
+      return `Migration${timestamp}_${name}`;
     },
     tableName: "migrations", // name of database table with log of executed transactions
     path: "./migrations", // path to the folder with migrations


### PR DESCRIPTION
### Description

For ORM configuration, The config for migration had a small issue in modifying the naming scheme. Probably it might be a mistype from your end. I have added the fix for that. 

